### PR TITLE
yacat: typo in command to run example (linux) causes example to fail

### DIFF
--- a/requestor-tutorials/task-processing-development/task-example-2-hashcat.md
+++ b/requestor-tutorials/task-processing-development/task-example-2-hashcat.md
@@ -694,7 +694,7 @@ Now, as we know how `yacat.py` works, let's run it!
 While in the `/examples/yacat` directory, type the following:
 
 ```python
-python3 yacat.py  --mask 'a?a?a' --hash '$P$5ZDzPE45CLLhEx/72qt3NehVzwN2Ry/'
+python3 yacat.py  --mask '?a?a?a' --hash '$P$5ZDzPE45CLLhEx/72qt3NehVzwN2Ry/'
 ```
 
 {% hint style="danger" %}


### PR DESCRIPTION
without this form for the mask the password will not be found. the mask is now the same as that used for the windows version.