### PR TITLE
changing mentions and technicalities from rinkeby to goerli

### DIFF
--- a/requestor-tutorials/flash-tutorial-of-requestor-development/README.md
+++ b/requestor-tutorials/flash-tutorial-of-requestor-development/README.md
@@ -82,7 +82,7 @@ git --version
 #### No crypto assets are needed (for now)
 
 {% hint style="info" %}
-During development, you'll most likely want to run your tasks on the Rinkeby Testnet. In that case, you won't need any real ETH or GLM tokens to start this tutorial. These test assets are acquired by the daemon in one of the steps below.
+During development, you'll most likely want to run your tasks on the Goerli Testnet. In that case, you won't need any real ETH or GLM tokens to start this tutorial. The test assets needed to transact on the Goerli Testnet and use the Golem testnet are acquired by the daemon in one of the steps below.
 
 Should you later want to run your tasks on the mainnet, to leverage the potential of all Golem's provider nodes, please have a look at: ["Using Golem on Mainnet"](../../payments/using-golem-on-mainnet/)
 {% endhint %}
@@ -187,7 +187,7 @@ the value in the `key` column is the key you need.
 
 ### Get some test GLM tokens
 
-In order to be able to request tasks on Golem, you'll need some GLM tokens (called tGLM on the rinkeby testnet) to pay the providers with. Even on the testnet, those tokens are still required but of course, you can easily get them issued to you using our tGLM faucet.
+In order to be able to request tasks on Golem, you'll need some GLM tokens to pay the providers with. While they don't have real value on the testnet, the tokens are still required. You can easily get them issued to you using our testnet GLM faucet.
 
 That's done using:
 
@@ -195,7 +195,7 @@ That's done using:
 yagna payment fund
 ```
 
-It tells yagna to check for funds on your node and if needed, contacts the faucet which, in turn, issues some test GLM and test ETH tokens to the node on the Rinkeby testnet.
+It tells yagna to check for funds on your node and if needed, contacts the faucet which, in turn, issues some test GLM and test ETH tokens to the node on the Goerli testnet.
 
 Once you issue the command, allow some time until it completes its job. You can verify whether you already have the funds with:
 

--- a/requestor-tutorials/flash-tutorial-of-requestor-development/run-first-task-on-golem.md
+++ b/requestor-tutorials/flash-tutorial-of-requestor-development/run-first-task-on-golem.md
@@ -139,5 +139,3 @@ Finally, you can verify that the providers have been paid for the work they cont
 ```
 yagna app-key list
 ```
-
-again but this time it's the value in the `id` column that you're interested in. This is your the Ethereum address of your yagna node on the Rinkeby testnet. Once you have that address, you can check that the transactions have been sent. For this, you can use our test utility: [https://github.com/golemfactory/testutil](https://github.com/golemfactory/testutil) .

--- a/troubleshooting/common-issues.md
+++ b/troubleshooting/common-issues.md
@@ -52,7 +52,7 @@ _**Os:**_ All, requestor only
 
 _**Description:**_ Since our newest addition to Golem - the integration with zkSync, layer 2 payment solution - is, so far, a highly experimental feature, it may still sometimes happen that the yagna daemon fails to initialize itself correctly.
 
-This will manifest itself either by a failure of the regular initialization with`yagna payment fund` or through an error you'll receive when running `yagna payment status`.
+This will manifest itself either by a failure of the regular initialization with `yagna payment fund` or through an error you'll receive when running `yagna payment status`.
 
 _**Solution:**_ In such a case, we're providing you with a fallback to normal payments, i.e. regular GLM token transfer on the Ethereum chain.
 
@@ -66,7 +66,7 @@ yagna payment init --sender --driver erc20
 
 After you confirm you have the funds, proceed with running the examples or your own requestor agent code normally. The providers are configured to accept both zkSync and the regular tokens and will adjust accordingly.
 
-Just remember to use [https://rinkeby.etherscan.io/](https://rinkeby.etherscan.io) instead of the zkSync explorer, should you wish to verify that the payment went through.
+Just remember to use [https://goerli.etherscan.io/](https://goerli.etherscan.io/) instead of the zkSync explorer, should you wish to verify that the payment went through.
 
 ## Bind error: already registered
 


### PR DESCRIPTION
For <https://handbook.golem.network/troubleshooting/common-issues#payment-driver-initialization-issue>, it is mentioning the usage of zkSync and rinkeby. I switched the links from rinkeby to goerli, however the page is still outdated but outside of the workorder.
﻿
Another thing, in the yagna daemon, it is called tGLM (see picture from my testing) and on the Goerli testnet it is called GLM. I removed the mention of it being called tGLM on X testnet, but let me know if this is still relevant to keep.

![image](https://github.com/golemfactory/yagna-docs/assets/64747030/55a73ba2-96f0-4f17-ad26-19aaa3cf193b)